### PR TITLE
autodetect file type

### DIFF
--- a/ftdetect/nc.vim
+++ b/ftdetect/nc.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.nc              set filetype=nc


### PR DESCRIPTION
When installed using Vundle, syntax highlighting is not working out-of-the-box -> copy the original ftdetect/nc.vim from the origin.
